### PR TITLE
Fix home page content and format loss

### DIFF
--- a/VERSION03/LabProjectPrelimsV2/src/ISLUStudentPortal.java
+++ b/VERSION03/LabProjectPrelimsV2/src/ISLUStudentPortal.java
@@ -520,6 +520,10 @@ public class ISLUStudentPortal extends JFrame {
         contentPanel.removeAll();
         switch (item.getName()) {
             case "🏠 Home":
+                // Restore Home's original two-column layout and styling
+                contentPanel.setLayout(new GridLayout(1, 2, 10, 10));
+                contentPanel.setBorder(new EmptyBorder(20, 20, 20, 20));
+                contentPanel.setBackground(Color.WHITE);
                 setupLayout(item.getSubItems());
                 break;
             case "📚 Journal/Periodical":
@@ -1506,9 +1510,14 @@ public class ISLUStudentPortal extends JFrame {
     
     // Navigate to home content
     private void showHomeContent() {
-        // TODO: Implement navigation back to home
-        // This should reset the sidebar selection and show the home content
-        // You can implement this based on your existing navigation logic
+        // Reset content panel to Home's original layout and repopulate
+        contentPanel.removeAll();
+        contentPanel.setLayout(new GridLayout(1, 2, 10, 10));
+        contentPanel.setBorder(new EmptyBorder(20, 20, 20, 20));
+        contentPanel.setBackground(Color.WHITE);
+        setupLayout(PortalUtils.createHomeSublist());
+        contentPanel.revalidate();
+        contentPanel.repaint();
     }
     
     // method for Personal Details Content


### PR DESCRIPTION
Restore Home view layout and content by resetting `contentPanel` to `GridLayout` when navigating back to Home.

When navigating away from Home, other sections changed the `contentPanel`'s layout, causing the Home view to appear broken or with missing content upon return because its original layout was not restored.

---
<a href="https://cursor.com/background-agent?bcId=bc-70b26edc-9291-4315-842c-ee40b1f5b4e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70b26edc-9291-4315-842c-ee40b1f5b4e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

